### PR TITLE
Performance: remove file check from autoloader.

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -164,11 +164,9 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 				}
 			}
 
-			if ( file_exists( $jetpack_packages_classes[ $class_name ]['path'] ) ) {
-				require_once $jetpack_packages_classes[ $class_name ]['path'];
+			require_once $jetpack_packages_classes[ $class_name ]['path'];
 
-				return true;
-			}
+			return true;
 		}
 
 		return false;


### PR DESCRIPTION
https://github.com/Automattic/jetpack-autoloader/blob/9249839bdee50f07e92d9fe10d48c699157c5d80/src/AutoloadGenerator.php#L68

Since we always optimize, remove expensive `file_exists()` calls from autoloader.

The current autoloader essentially enforces Composer's [Optimization Level 1](https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-1-class-map-generation).

This PR seeks to enforce [Optimization Level 2]() as well.

In testing WooCommerce + WooCommerce Admin (which both use this autoloader), requests were seeing ~375 calls to `file_exists()` and spending 1+ seconds Wall time. With this change, those numbers are down to ~90 calls and ~0.2 seconds.